### PR TITLE
Feature/dosage uom changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Current approved version published on [https://developer.nhs.uk/apis/dose-syntax
 
 To contribute to the repository, please ensure you update your local repository so it is inline with the latest changes with the origin e.g. `git fetch` and `git pull`.
 
-If you have an old version of this repository before 3rd Feb 2021, you may want to reset your local `master` and `gh-pages` branches with origin.
-For example: `git reset --hard origin/master` or `git reset --hard origin/gh-pages`.
+If you have an old version of this repository before 3rd Feb 2021, you may want to reset your local `master` branch with origin.
+For example: `git reset --hard origin/master`.
 
-### Branch strategy
+### Branching strategy
 
-This repository uses [GitHub Flow](https://guides.github.com/introduction/flow/) for the branch strategy.
+This repository uses [GitHub Flow](https://guides.github.com/introduction/flow/) for the branching strategy.
 
 #### Branches
 
@@ -37,7 +37,7 @@ Please do not commit to the `master` branch directly. Instead, please create a f
 
 Please ensure your commit messages are relevant to the feature you're creating - for example:
 
-`git commit -m "Fixed spelling mistake in README.md"`'
+`git commit -m "Fixed spelling mistake in README.md"`
 
 #### Making a Pull / Merge request
 

--- a/_data/sidebars/overview_sidebar.yml
+++ b/_data/sidebars/overview_sidebar.yml
@@ -1,7 +1,7 @@
 entries:
-- title: Dose Syntax Implementation 
-  product: Dose Syntax Implementation for FHIR
-  version: 1.3.2 - Alpha
+- title: Dose Syntax Implementation
+  product: Dose Syntax Implementation for FHIR STU3
+  version: 1.3.3-beta
   levels: one
   folders:
 
@@ -37,8 +37,8 @@ entries:
       output: web
     - title: CareConnect-MedicationStatement-1
       url: /careconnect-MedicationStatement-1.html
-      output: web 
-      
+      output: web
+
   - title: Dosage Structure
     output: web,pdf
     folderitems:
@@ -66,7 +66,7 @@ entries:
       output: web
     - title: maxDosePer[x]
       url: /dosage-maxdoseper.html
-      output: web    
+      output: web
     - title: additional, patientInstruction, text
       url: /dosage-additional-patient.html
       output: web
@@ -101,7 +101,7 @@ entries:
       output: web
     - title: 2. Maximum dose per course
       url: /dosage-maxdose.html
-      output: web        
+      output: web
     - title: 3. Periods of no medicine administration
       url: /dosage-no-meds.html
       output: web
@@ -122,7 +122,7 @@ entries:
     - title: Text Generation Logic
       url: /dosage-to-narrative-logic.html
       output: web
-      
+
   - title: Appendix - Dose to Product Translation
     output: web,pdf
     folderitems:
@@ -133,8 +133,8 @@ entries:
     - title: Dose to Product Logic
       url: /dosage-to-product-logic.html
       output: web
-      
-      
+
+
   - title: Help & Support
     output: web
     folderitems:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -101,4 +101,9 @@
 {% if site.google_analytics %}
 {% include google_analytics.html %}
 {% endif %}
+
+{% if page.mathjax  %}
+<script type="text/javascript" async src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML'></script>
+{% endif %}
+
 </html>

--- a/pages/explore/dosage-doseQuantity-freq-period.md
+++ b/pages/explore/dosage-doseQuantity-freq-period.md
@@ -1,43 +1,83 @@
 ---
 title: Dosage dose[x], frequency and period
-keywords:  messaging
-tags: [fhir,messaging]
+keywords: messaging
+tags: [fhir, messaging]
 sidebar: foundations_sidebar
 permalink: dosage-doseQuantity-freq-period.html
 summary: "Simple timing instructions using dose[x], frequency and period"
+mathjax: true
 ---
 
+> A large proportion of cases, especially those where the medication are described using a VMP or AMP concept, can have a dosage instruction defined as a **doseQuantity** plus a combination of **frequency** and **period** elements within the [Timing structure](http://hl7.org/fhir/STU3/datatypes.html#Timing).
 
+## Units of Measure
 
-A large proportion of cases, especially those where the medication is described using a VMP or AMP concept, can have a dosage instruction defined as a **doseQuantity** plus a combination of **frequency** and **period** elements within the Timing structure.
+A unit of measure is required when [describing a dosage](#describing-a-dose) and can be supplied via one of the following:
 
-## Dosage.doseQuantity ##
+### UCUM
 
-The **doseQuantity** is one of two ways to describe a dose; the amount of medication per dose, as a simple coded quantity. The alternative is with a **doseRange**.
+[The Unified Code for Units of Measure](http://unitsofmeasure.org) (UCUM) is preferred and should be used where possible.
 
-By preference, use UCUM units of measure (system URL: “http://unitsofmeasure.org”). 
-Examples of when a UCUM unit of measure would be used are “gram” or “milliliter” or “percent”.
+Examples of when a UCUM unit of measure would be used are:
 
-Where a UCUM unit of measure is not defined, use a SNOMED-CT unit of measure (system URL: “http://snomed.info/sct”).  
-Examples of when a SNOMED-CT unit of measure would typically be used are “tablet”, “capsule” or “ampule”.  
-Units of presentation relevant to medication dosage instructions are contained within the hierarchy as descendants of [732935002 | Unit of presentation](https://termbrowser.nhs.uk/?perspective=full&conceptId1=732935002&edition=uk-edition).  
-Units of measure, where UCUM is not available, are contained within the hierarchy as descendants of [767524001 | Unit of measure](https://termbrowser.nhs.uk/?perspective=full&conceptId1=767524001&edition=uk-edition).  
+- gram (g)
+- milliliter (ml)
+- percent (%)
 
+### SNOMED-CT
 
+In the instance where a UCUM unit of measure is not defined, use a [SNOMED-CT](https://datadictionary.nhs.uk/data_elements/unit_of_measurement__snomed_ct_dm_d_.html) unit of measure instead.
+
+Examples of where a SNOMED-CT unit of measure would typically be used are:
+
+- tablet
+- capsule
+- ampoule
+
+All units of measure are descendants of concept [`767524001 | Unit of measure (qualifier value) |`](https://termbrowser.nhs.uk/?perspective=full&conceptId1=767524001&edition=uk-edition,999000691000001104) which includes both UCUM and non-UCUM codes.
+
+Concept [`732935002 | Unit of presentation (unit of presentation) |`](https://termbrowser.nhs.uk/?perspective=full&conceptId1=732935002&edition=uk-edition), which is also a descendant of the Unit of measure concept, holds a list non-UCUM units of measure that are used within prescribing, such as:
+
+- tablet
+- pad
+- patch
+
+## Describing a dosage
+
+A dosage can be described via one of the following methods. In both instances when considering Units of Measure note that UCUM is preferred.
+
+### Dosage.doseQuantity
+
+The amount of medication per dose, as a [simple coded quantity](http://hl7.org/fhir/STU3/datatypes.html#SimpleQuantity).
 
 <script src="https://gist.github.com/IOPS-DEV/f57f25fa61f77bdf837919d0e676b2b2.js"></script>
 
-## Dosage.doseRange ##
+### Dosage.doseRange
 
-The **doseRange** is used to describe a dose that may be in a given low/high range. By preference, use UCUM units of measure, but where not defined, use SNOMED-CT units.
+A dose that may be in a given low/high range.
 
 <script src="https://gist.github.com/IOPS-DEV/8e95e65ffbcae8b797b5f5d0cf76274d.js"></script>
 
-## Dosage.timing.repeat.frequency and Dosage.timing.repeat.period ##
+## Dosage.timing.repeat.frequency and Dosage.timing.repeat.period
 
-Simple dosage timing instructions can be described using **frequency** and **period**. The combination of frequency and period allows for the two commonly used expressions of "X times a period" and "every X period".
+Simple dosage timing instructions can be described using **frequency** and **period**.
 
-The unit of the period must be one of the UCUM units; s = second; min = minute; h = hour; d =day; wk = week; mo =month; a = year.
+The combination of frequency and period allows for the two commonly used expressions of:
+
+- $$x$$ times a period
+- every $$x$$ period
+
+The unit of the period **must be** one of the UCUM units:
+
+| UCUM Unit | Definition |
+| --------- | ---------- |
+| `s`       | second     |
+| `min`     | minute     |
+| `h`       | hour       |
+| `d`       | day        |
+| `wk`      | week       |
+| `mo`      | month      |
+| `a`       | year       |
 
 A **frequencyMax** and/or **periodMax** can also be used to define ranges.
 

--- a/pages/overview/overview_release_notes.md
+++ b/pages/overview/overview_release_notes.md
@@ -7,59 +7,68 @@ permalink: overview_release_notes.html
 summary: Summary release notes of the versions of the FHIR Dose Syntax Implementation Guidance
 ---
 
-## Scope ##
+## Scope
 
-### Inclusions ###
+### Inclusions
 
-* Use of STU3 Dosage structure within CareConnect profiled resources
-* Worked examples using the CareConnect-MedicationRequest-1 profiled resource
-* Guidance (experimental) for converting a dose-based (VTM) instruction into an appropriate short list of (VMP/AMP) products 
-* Guidance (experimental) for creating a human readable string from the FHIR Dosage elements
+- Use of STU3 Dosage structure within CareConnect profiled resources
+- Worked examples using the CareConnect-MedicationRequest-1 profiled resource
+- Guidance (experimental) for converting a dose-based (VTM) instruction into an appropriate short list of (VMP/AMP) products
+- Guidance (experimental) for creating a human readable string from the FHIR Dosage elements
 
-### Exclusions ####
+### Exclusions
 
 The following will be added to future versions of this implementation guidance.
-* Guidance for converting existing prescription content (e.g. an order sentence) within an existing prescribing system into a FHIR Dosage instruction
-* Guidance for creating patient focussed dosage instructions when converting from a dose-based to product-based instruction
 
-## Version History ##
+- Guidance for converting existing prescription content (e.g. an order sentence) within an existing prescribing system into a FHIR Dosage instruction
+- Guidance for creating patient focussed dosage instructions when converting from a dose-based to product-based instruction
 
-### 1.3.2-alpha ###
+## Version History
 
-* updated external links to the AWS demonstrator with links to the demonstrator and associated API documentation provided by the North of England Commissioning Support Unit
+### 1.3.3-beta
 
-### 1.3.1-alpha ###
+- Updated to beta
+- Updated the [`dosage-doseQuantity-freq-period.html`](dosage-doseQuantity-freq-period.html) page to include additional information regarding units of measure, and updated formatting.
 
-* review comment clarifications
-* clarification of use of UCUM units of measure versus SNOMED CT units of measure and presentation
-* clarification of use of SNOMED synonyms
-* clarification of use of additionalInstruction, patientInstruction, text
-* rearrange examples to illustrate standar use of dose syntax, use of additionalInstruction, use of patientInstruction
-* additional example of use of Medication not in dm+d \(2nd Glucose 5% infusion example\)
+### 1.3.2-alpha
 
-### 1.3.0-alpha ###
-* Reorganisation of content to foreground Dose Syntax versus background Medicines context
-* Examples rework to conform to CareConnect medication profiling
-* Dose to Product & CareConnect Text Narrative moved to appendix pending scoping decisions
+- updated external links to the AWS demonstrator with links to the demonstrator and associated API documentation provided by the North of England Commissioning Support Unit
 
-### 1.2.0-experimental ###
-* 'Dose to Product Translation' section added
+### 1.3.1-alpha
 
-### 1.1.0-experimental ###
-* 'CareConnect Resources' section updated
-  * Where a specific Trade Family (i.e brand name) is to be specified, an AMP concept must be used until a FHIR profiled resource can support a coded Trade Family concept.
-  * Guidance and example for use of medicationDispense.quantity added.
-* 'Dosage Structure' section updated
-  * Moved the Dosage.asNeeded[x] guidance it it's own section.
-  * New section for the Dosage.maxDosePer[x] structure.
-  * Updated the 'additionalInstructions, patientInstructions' section to include a note on using coded concepts that relate to specific dosing timing instructions.
-  * Change to use of Dosage.text and inclusion of Dosage.timing.code
-  * Updated the 'Dosage doseQuantity, frequency, period' section to include guidance on doseRange.
-* 'CareConnect Text Narrative' section added
-* Fixed bugs within some of the worked FHIR XML examples 
-* Additional FHIR XML examples to highlight difference between dose-based and product-based instructions.
-* Some examples removed where these covered duplicate aspects of the Dosage structure.
+- review comment clarifications
+- clarification of use of UCUM units of measure versus SNOMED CT units of measure and presentation
+- clarification of use of SNOMED synonyms
+- clarification of use of additionalInstruction, patientInstruction, text
+- rearrange examples to illustrate standar use of dose syntax, use of additionalInstruction, use of patientInstruction
+- additional example of use of Medication not in dm+d \(2nd Glucose 5% infusion example\)
 
-### 1.0.0-experimental ###
+### 1.3.0-alpha
+
+- Reorganisation of content to foreground Dose Syntax versus background Medicines context
+- Examples rework to conform to CareConnect medication profiling
+- Dose to Product & CareConnect Text Narrative moved to appendix pending scoping decisions
+
+### 1.2.0-experimental
+
+- 'Dose to Product Translation' section added
+
+### 1.1.0-experimental
+
+- 'CareConnect Resources' section updated
+  - Where a specific Trade Family (i.e brand name) is to be specified, an AMP concept must be used until a FHIR profiled resource can support a coded Trade Family concept.
+  - Guidance and example for use of medicationDispense.quantity added.
+- 'Dosage Structure' section updated
+  - Moved the Dosage.asNeeded[x] guidance it it's own section.
+  - New section for the Dosage.maxDosePer[x] structure.
+  - Updated the 'additionalInstructions, patientInstructions' section to include a note on using coded concepts that relate to specific dosing timing instructions.
+  - Change to use of Dosage.text and inclusion of Dosage.timing.code
+  - Updated the 'Dosage doseQuantity, frequency, period' section to include guidance on doseRange.
+- 'CareConnect Text Narrative' section added
+- Fixed bugs within some of the worked FHIR XML examples
+- Additional FHIR XML examples to highlight difference between dose-based and product-based instructions.
+- Some examples removed where these covered duplicate aspects of the Dosage structure.
+
+### 1.0.0-experimental
+
 First version published.
-


### PR DESCRIPTION
[dosage-doseQuantity-freq-period.pdf](https://github.com/nhsconnect/Dose-Syntax-Implementation/files/5926486/dosage-doseQuantity-freq-period.pdf)

PDF attached to visualise changes.
Current version [here](https://developer.nhs.uk/apis/dose-syntax-implementation/dosage-doseQuantity-freq-period.html)

**Changes**

- Removed reference to `gh-pages` in the `README.md`
- Updated `dosage-doseQuantity-freq-period` following feedback from Bill Lush - including document structure change
-- original: 
- Added link to MathJax with dynamic usage for mathematical notation (where appropriate)
- Updated version to 1.3.3-beta and stipulated FHIR STU3 in the sidebar heading (see image below)

![image](https://user-images.githubusercontent.com/4058190/106915657-2f867780-66fe-11eb-9cea-7f5907ae53ef.png)
